### PR TITLE
Add option to customise page title

### DIFF
--- a/src/main/resources/templates/mopslayout.html
+++ b/src/main/resources/templates/mopslayout.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <title th:text="'Mops' + (${name} ? ' - ' + ${name} : '')">Mops</title>
+  <title th:text="'Mops' + (${customtitle} ? ' - ' + ${customtitle}  : (${name} ? ' - ' + ${name} : ''))">Mops</title>
   <link href="../static/css/bootstrap.min.css" rel="stylesheet" th:href="@{/css/bootstrap.min.css}">
   <link href="../static/css/icono.min.css" rel="stylesheet" th:href="@{/css/icono.min.css}">
   <link href="../static/css/styles.min.css" rel="stylesheet" th:href="@{/css/styles.min.css}">

--- a/src/main/resources/templates/mopslayout.html
+++ b/src/main/resources/templates/mopslayout.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <title th:text="'Mops' + (${customtitle} ? ' - ' + ${customtitle}  : (${name} ? ' - ' + ${name} : ''))">Mops</title>
+  <title th:text="'Mops' + (${title} ? ' - ' + ${title}  : (${name} ? ' - ' + ${name} : ''))">Mops</title>
   <link href="../static/css/bootstrap.min.css" rel="stylesheet" th:href="@{/css/bootstrap.min.css}">
   <link href="../static/css/icono.min.css" rel="stylesheet" th:href="@{/css/icono.min.css}">
   <link href="../static/css/styles.min.css" rel="stylesheet" th:href="@{/css/styles.min.css}">


### PR DESCRIPTION
Von einer Gruppe wurde gewünscht, dass man den Tabtitel für verschiedene Seiten anpassen kann. Ich habe dafür im <title>-Tag einen zweiten ternären Ausdruck eingefügt, damit man den Titel mit der Variable 'customtitle' anpassen kann. Sollte customtitle nicht gesetzt werden, sollte die Änderung keinen Einfluss haben.