### PR TITLE
Entferne tote Zeilen in der README

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -274,16 +274,6 @@ public class Account {
   <div class="alert alert-warning" role="alert">
     Die Suche selbst bietet noch keinen Bereich, in dem Suchergebnisse gelistet werden. Dies muss im Fragment <code>bodycontent</code> geschehen.
   </div>
-
-  <h2 id="mops">Kennzeichnung von Komponenten</h2>
-  <p>
-    Jedem Tag <code>x</code> sollte das Attribut <code>is="mops-x"</code> angehangen werden. Beispiel:
-  </p>
-  <pre>
-    <code>
-&lt;nav ... is="mops-nav"&gt; ... &lt;/nav&gt;
-    </code>
-  </pre>
 </main>
 </body>
 </html>


### PR DESCRIPTION
Der Hinweis *überall* ein `is=` dranzupacken, ist nicht sinnvoll. Wenn wir das überall nach einem bestimmten Schema machen, können wir genauso gut ein JavaScript fürs Präprozessing drüber laufen lassen und danach mit WebComponents o.Ä. arbeiten.